### PR TITLE
Friendly icons for quality indication

### DIFF
--- a/server.R
+++ b/server.R
@@ -34,6 +34,13 @@ function(input, output, session) {
     
   })
   
+  pass_icon <- '<span style="color: Teal; font-size: 150%;">
+            <i class="fas fa-check"></i>
+            </span>'
+  fail_icon <- '<span style="color: Tomato; font-size: 150%;">
+            <i class="fas fa-times"></i>
+            </span>'
+  
   output$headerPrioritization <- renderUI({
     list(h2("Prioritization Report"),
          h4("Literally Homeless Clients as of", meta_HUDCSV_Export_End))
@@ -2543,7 +2550,10 @@ function(input, output, session) {
             DQflag == 3 ~ "", # "Docs received, not yet scored",
             DQflag == 4 ~ "", # "CoC Error",
             DQflag == 5 ~ "" # "Docs received past the due date"
-          )
+          ),
+          DQ = case_when(
+            DQflag == 0 ~ pass_icon,
+            DQflag == 1 ~ fail_icon)
         ) %>%
         filter(!Measure %in% c("Moved into Own Housing",
                                "Average Length of Stay")) %>%
@@ -2600,10 +2610,12 @@ function(input, output, session) {
         } else if(ptc == 2) {
           th
         },
+        escape = FALSE,
         rownames = FALSE,
         options = list(dom = 't',
                        pageLength = 100)
-      )
+      ) %>%
+        formatStyle('Data Quality', textAlign = 'center')
     })
   
   output$pe_ExitsToPH <- DT::renderDataTable({


### PR DESCRIPTION
Here is the code for those icons! The format for setting them up can go at the top of the server file as variables, then you can reference them easily throughout for consistency. The anatomy is:

```
  [icon_name] <- '<span style="color: [color]; font-size: 150%;">
            <i class="fas fa-[icon_name]"></i>
            </span>'
```

Setting the size to 150% seems to make them look more appropriately sized next to regular text--when they're normal size, they fit nicely in-line, but look odd in their own column. I used [Font Awesome](https://fontawesome.com/icons) icons, so swapping out the indicated icon name for a name in their library should work just fine. I believe you can also use Glyphicon icons based on [this link](https://gist.github.com/cecilialee/e848068cfd5862fd63961b03b42ead78), but went with Font Awesome for this because it seemed simpler.

Resolves #58 