### PR TITLE
Add veteran status filter

### DIFF
--- a/server.R
+++ b/server.R
@@ -1732,7 +1732,10 @@ function(input, output, session) {
   output$VeteranActiveList <- DT::renderDataTable({
 
     vet_active_list <- veteran_active_list() %>%
-      filter(County %in% c(input$vetCounty)) %>%
+      filter(County %in% c(input$vetCounty) &
+               if_else(is.na(veteran_active_list()$ListStatus),
+                       "No Status Set",
+                       veteran_active_list()$ListStatus) %in% c(input$vetStatus)) %>%
       arrange(PersonalID) %>%
       mutate(PersonalID = if_else(
         is.na(HOMESID),

--- a/ui.R
+++ b/ui.R
@@ -316,6 +316,28 @@ dashboardPage(
                 ), width = 12)),
                 fluidRow(
                   box(
+                    title = "Enrollments",
+                    HTML("<p><span style=\"background-color: lavenderblush;\">Housing Project</span></p>
+                    <p><span style=\"background-color: lightgoldenrodyellow;\">Literally Homeless Project</span></p>
+                    <p><span style=\"background-color: paleturquoise;\">Other Project</span></p>"),
+                    width = 3
+                  ),
+                  box(
+                    title = "Eligibility",
+                    htmlOutput("veteranActiveListEligibilityLegend"),
+                    width = 5
+                  ),
+                  box(
+                    title = "Housing Track & Notes",
+                    HTML("<p><span style=\"color: seagreen;\">Expected PH Date on or after today</span></p>
+                    <p><span style=\"color: tomato;\">Expected PH Date in the past</span></p>
+                    <p>No Expected PH Date recorded</p>"),
+                    width = 4
+                  ),
+                  width = 12
+                ),
+                fluidRow(
+                  box(
                     pickerInput(
                       label = "Select County/-ies",
                       inputId = "vetCounty",
@@ -329,26 +351,27 @@ dashboardPage(
                       )
                     ),
                     downloadButton("downloadVeteranActiveList", "Download"),
-                    width = 3
+                    width = 6
                   ),
                   box(
-                    title = "Enrollments",
-                    HTML("<p><span style=\"background-color: lavenderblush;\">Housing Project</span></p>
-                    <p><span style=\"background-color: lightgoldenrodyellow;\">Literally Homeless Project</span></p>
-                    <p><span style=\"background-color: paleturquoise;\">Other Project</span></p>"),
-                    width = 2
-                  ),
-                  box(
-                    title = "Eligibility",
-                    htmlOutput("veteranActiveListEligibilityLegend"),
-                    width = 4
-                  ),
-                  box(
-                    title = "Housing Track & Notes",
-                    HTML("<p><span style=\"color: seagreen;\">Expected PH Date on or after today</span></p>
-                    <p><span style=\"color: tomato;\">Expected PH Date in the past</span></p>
-                    <p>No Expected PH Date recorded</p>"),
-                    width = 3
+                    pickerInput(
+                      label = "Select Status/s",
+                      inputId = "vetStatus",
+                      multiple = TRUE,
+                      choices = sort(
+                        unique(
+                          if_else(is.na(veteran_active_list()$ListStatus),
+                                  "No Status Set",
+                                  veteran_active_list()$ListStatus))),
+                      selected = c("Active - ES/TH",
+                                   "Active - Unsheltered",
+                                   "No Status Set"),
+                      options = pickerOptions(
+                        liveSearch = TRUE,
+                        liveSearchStyle = 'contains',
+                        actionsBox = TRUE
+                      )
+                    )
                   ),
                   width = 12
                 ),


### PR DESCRIPTION
This adds a filter to the veteran active list page to let folks filter the displayed list by status! 

It automatically picks active folks and those with missing statuses when loaded because I anticipate those being the most common , but of course it can easily be changed. Neat thing about this is that because the list is actually filtered, counties can use the row count displayed at the bottom to track their number of actively homeless veterans!