### PR TITLE
USICH Benchmark Tab

### DIFF
--- a/global.R
+++ b/global.R
@@ -32,6 +32,8 @@ if (!exists("df_nms")) {
   list2env(readRDS("data/Rminor_elevated.rds"), e)
 }
 
+`%nin%` = Negate(`%in%`)
+
 providers <- sort(validation()$ProjectName) %>% unique() 
 
 desk_time_providers <- validation() %>%

--- a/server.R
+++ b/server.R
@@ -1861,6 +1861,62 @@ function(input, output, session) {
     }
   )
   
+           
+  output$usich_1 <-  renderValueBox({
+    valueBox(
+      value = nrow(veteran_active_list() %>%
+                  filter((ListStatus != "Inactive (Non-Permanent Housing)" &
+                           ListStatus != "Inactive (Permanently Housed)") &
+                           (County %in% c(input$vetBenchmarkCounty) |
+                              is.na(County)))),
+      subtitle = "Active Veterans",
+      icon = icon("remove"), width = 4, color = "red")
+  })
+  
+  output$usich_2 <-  renderValueBox({
+    valueBox(
+      value = nrow(veteran_active_list() %>%
+                     filter((ListStatus != "Inactive (Non-Permanent Housing)" &
+                              ListStatus != "Inactive (Permanently Housed)" &
+                              ChronicStatus %in% c("Chronic", "Aged In")) &
+                              (County %in% c(input$vetBenchmarkCounty) |
+                                 is.na(County)))),
+      subtitle = "Chronic Active Veterans",
+      icon = icon("remove"), width = 4, color = "red")
+  })
+  
+  output$usich_3 <-  renderValueBox({
+    valueBox(
+      value = nrow(veteran_active_list() %>%
+                     filter(ListStatus != "Inactive (Non-Permanent Housing)" &
+                              ListStatus != "Inactive (Permanently Housed)" &
+                              (ChronicStatus %in% c("Chronic", "Aged In") |
+                                 LongTermStatus == "Long Term") &
+                              (County %in% c(input$vetBenchmarkCounty) |
+                                 is.na(County)))),
+      subtitle = "Chronic and Long-Term Active Veterans",
+      icon = icon("remove"), width = 4, color = "red")
+  })
+  
+  output$usich_4 <-  renderValueBox({
+    valueBox(
+      value = nrow(veteran_active_list() %>%
+                     filter(ListStatus != "Inactive (Non-Permanent Housing)" &
+                              ListStatus != "Inactive (Permanently Housed)" &
+                              (ChronicStatus %in% c("Chronic", "Aged In") |
+                                 LongTermStatus == "Long Term") &
+                              (County %in% c(input$vetBenchmarkCounty) |
+                                 is.na(County)) &
+                              (OfferDate >= today() - days(14) |  ## group 1
+                                 # |                                ## need to add group 2
+                                 (AcceptDeclineDate >= today() - days(90) &
+                                    OfferAccepted == "Yes")
+                                 )
+                              )),
+      subtitle = "Excluded Veterans",
+      icon = icon("remove"), width = 4, color = "red")
+  })
+  
   output$DQWarnings <- DT::renderDataTable({
     ReportStart <- format.Date(input$dq_startdate, "%m-%d-%Y")
     ReportEnd <- format.Date(meta_HUDCSV_Export_Date, "%m-%d-%Y")

--- a/ui.R
+++ b/ui.R
@@ -399,6 +399,10 @@ dashboardPage(
       tabItem(
         tabName = "dashUSICH",
         fluidPage(
+          tags$style(".small-box.bg-black { background-color: #778899 !important;}"),
+          fluidRow(box(htmlOutput(
+            "headerUSICH"
+          ), width = 12)),
           fluidRow(
             box(
               pickerInput(
@@ -413,14 +417,15 @@ dashboardPage(
                   liveSearch = TRUE,
                   liveSearchStyle = 'contains',
                   actionsBox = TRUE
-                )),
-              width = 12
-            )),
-          fluidRow(valueBoxOutput("usich_1"),
-                   valueBoxOutput("usich_2"),
-                   valueBoxOutput("usich_3")),
-          fluidRow(valueBoxOutput("usich_4"))
-        )
+                )))),
+          fluidRow(
+            valueBoxOutput("usich_1", width = 12)),
+          fluidRow(
+            valueBoxOutput("usich_2", width = 12)),
+          fluidRow(
+            valueBoxOutput("usich_3", width = 12)),
+          fluidRow(
+            valueBoxOutput("usich_4", width = 12)))
       ),
       tabItem(
         tabName = "dqTab",

--- a/ui.R
+++ b/ui.R
@@ -26,8 +26,8 @@ dashboardPage(
                tabName = "currentProviderLevel"),
       menuItem(
         "Ending Veteran Homelessness",
-        menuSubItem("Active List (Beta)", tabName = "vetActiveList")#,
-        # menuSubItem("USICH Benchmarks", tabName = "dashUSICH"),
+        menuSubItem("Active List (Beta)", tabName = "vetActiveList"),
+        menuSubItem("USICH Benchmarks (Beta)", tabName = "dashUSICH")#,
         # menuSubItem("Inflow Outflow", tabName = "flow")
       ),
       menuItem("COVID-19 Vaccine Distribution",
@@ -396,6 +396,32 @@ dashboardPage(
                     width = 12
                   ))
               )),
+      tabItem(
+        tabName = "dashUSICH",
+        fluidPage(
+          fluidRow(
+            box(
+              pickerInput(
+                label = "Select County/-ies",
+                inputId = "vetBenchmarkCounty",
+                multiple = TRUE,
+                choices = regions() %>%
+                  arrange(County) %>% pull(County),
+                selected = regions() %>%
+                  arrange(County) %>% pull(County),
+                options = pickerOptions(
+                  liveSearch = TRUE,
+                  liveSearchStyle = 'contains',
+                  actionsBox = TRUE
+                )),
+              width = 12
+            )),
+          fluidRow(valueBoxOutput("usich_1"),
+                   valueBoxOutput("usich_2"),
+                   valueBoxOutput("usich_3")),
+          fluidRow(valueBoxOutput("usich_4"))
+        )
+      ),
       tabItem(
         tabName = "dqTab",
         fluidRow(box(htmlOutput(


### PR DESCRIPTION
`global`
Just added a negation to let me use %nin% to check for things that are not in a list. Only needed it twice here, but it's useful enough I wanted to add it in.

`server`
- created USICH page header in line with VBNL page header
- created a single value box for each metric. They are teal with check marks if they pass, red with x's if they fail, and temporarily set to black with a 'missing' icon when the metric isn't applicable based on the data available. 
- all of the metrics are filtered by county
> - Metric one gets the full list of veterans who are not excluded (any offer in last 14 days, opted for transitional housing, or accepted offer within last 90 days but still looking for housing) and displays the count of chronic and long-term veterans in that list. 
> - Metric two gets the longest enrollment leading to a housed exit for each veteran housed in the last 90 days and uses the sum of those enrollment lengths divided by the number housed to find the average. I kept only the longest enrollment for each person to avoid overlap errors that seemed possible based on the original calculation, but we can remove the `slice` if we want all housed enrollments!
> - Metric three counts up the newly homeless veterans (excluding those that were housed in the last 90 days) and divides that number by the total number of veterans housed to get a rough inflow/outflow proportion
> - Metric four divides the number of new GPD entries by the total number of new veterans

`ui`
This mainly just displays the pieces set up in the `server` file, but it does one special thing: it has a little css in it that makes the 'black' value boxes created for irrelevant metrics display as a much more neutral grey color.